### PR TITLE
Using another evaluation scheme for polynoms

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -15,7 +15,7 @@ fn bench_type_k_celcius(b: &mut Bencher) {
 
     b.iter(|| {
         let _: Celsius =
-            thermocouple.sense_temperature(Millivolts(2.0));
+            thermocouple.sense_temperature(Millivolts(2.10));
     });
 }
 ///

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -14,8 +14,10 @@ fn bench_type_k_celcius(b: &mut Bencher) {
     let thermocouple = thermocouple::KType::new();
 
     b.iter(|| {
-        let _: Celsius =
-            thermocouple.sense_temperature(Millivolts(2.10));
+        for i in 0..1000000 {
+            let _: Celsius =
+                thermocouple.sense_temperature(Millivolts(2.0));
+        }
     });
 }
 ///

--- a/src/e_type.rs
+++ b/src/e_type.rs
@@ -1,6 +1,6 @@
 //! E-Type thermocouple data
+use crate::polyval::polyval;
 use crate::{Celsius, Millivolts, FP};
-
 const E_TYPE_E_BELOW_0: [FP; 14] = [
     0.000000000000E+00,
     0.586655087080E-01,
@@ -68,51 +68,11 @@ pub fn e(t: Celsius) -> Millivolts {
     let e = match t > 0.0 {
         false => {
             // -270ºC -> 0ºC
-            const C: [FP; 14] = E_TYPE_E_BELOW_0;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
-                + C[9] * t * t * t * t * t * t * t * t * t
-                + C[10] * t * t * t * t * t * t * t * t * t * t
-                + C[11] * t * t * t * t * t * t * t * t * t * t * t
-                + C[12] * t * t * t * t * t * t * t * t * t * t * t * t
-                + C[13]
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
+            polyval(E_TYPE_E_BELOW_0, t)
         }
         _ => {
             // 0ºC -> 1000ºC
-            const C: [FP; 11] = E_TYPE_E_ABOVE_0;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
-                + C[9] * t * t * t * t * t * t * t * t * t
-                + C[10] * t * t * t * t * t * t * t * t * t * t
+            polyval(E_TYPE_E_ABOVE_0, t)
         }
     };
 
@@ -133,23 +93,10 @@ pub fn t(e: Millivolts) -> Celsius {
     #[cfg(not(any(feature = "extrapolate")))]
     assert!(e <= 76.373 + TOL);
 
-    let c = match e < 0.0 {
-        true => E_TYPE_T0,
-        false => E_TYPE_T1,
+    let ps = match e < 0.0 {
+        true => polyval(E_TYPE_T0, e),
+        false => polyval(E_TYPE_T1, e),
     };
-
-    // Power Series
-    let ps = c[0]
-        + c[1] * e
-        + c[2] * e * e
-        + c[3] * e * e * e
-        + c[4] * e * e * e * e
-        + c[5] * e * e * e * e * e
-        + c[6] * e * e * e * e * e * e
-        + c[7] * e * e * e * e * e * e * e
-        + c[8] * e * e * e * e * e * e * e * e
-        + c[9] * e * e * e * e * e * e * e * e * e;
-
     Celsius(ps)
 }
 

--- a/src/j_type.rs
+++ b/src/j_type.rs
@@ -1,6 +1,6 @@
 //! J-Type thermocouple data
+use crate::polyval::polyval;
 use crate::{Celsius, Millivolts, FP};
-
 const J_TYPE_E_BELOW_760: [FP; 9] = [
     0.000000000000E+00,
     0.503811878150E-01,
@@ -67,28 +67,11 @@ pub fn e(t: Celsius) -> Millivolts {
     let e = match t > 760.0 {
         false => {
             // -210ºC -> 760ºC
-            const C: [FP; 9] = J_TYPE_E_BELOW_760;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
+            polyval(J_TYPE_E_BELOW_760, t)
         }
         _ => {
             // 760ºC -> 1200ºC
-            const C: [FP; 6] = J_TYPE_E_ABOVE_760;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
+            polyval(J_TYPE_E_ABOVE_760, t)
         }
     };
 
@@ -115,16 +98,7 @@ pub fn t(e: Millivolts) -> Celsius {
         (false, false) => J_TYPE_T2,
     };
 
-    // Power Series
-    let ps = c[0]
-        + c[1] * e
-        + c[2] * e * e
-        + c[3] * e * e * e
-        + c[4] * e * e * e * e
-        + c[5] * e * e * e * e * e
-        + c[6] * e * e * e * e * e * e
-        + c[7] * e * e * e * e * e * e * e
-        + c[8] * e * e * e * e * e * e * e * e;
+    let ps = polyval(c, e);
 
     Celsius(ps)
 }

--- a/src/k_type.rs
+++ b/src/k_type.rs
@@ -1,4 +1,5 @@
 //! K-Type thermocouple data
+use crate::polyval::polyval;
 use crate::{Celsius, Millivolts, FP};
 
 #[cfg(any(feature = "f32"))]
@@ -84,39 +85,14 @@ pub fn e(t: Celsius) -> Millivolts {
     let e = match t > 0.0 {
         false => {
             // -270ºC -> 0ºC
-            const C: [FP; 11] = K_TYPE_E_BELOW_0;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
-                + C[9] * t * t * t * t * t * t * t * t * t
-                + C[10] * t * t * t * t * t * t * t * t * t * t
+            polyval(K_TYPE_E_BELOW_0, t)
         }
         _ => {
             // 0ºC -> 1372ºC
-            const C: [FP; 10] = K_TYPE_E_ABOVE_0;
             let a0 = 0.118597600000E+00;
             let a1 = -0.118343200000E-03;
             let a2 = 0.126968600000E+03;
-
-            // Power Series
-            let ps = C[0]
-                + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
-                + C[9] * t * t * t * t * t * t * t * t * t;
-
+            let ps = polyval(K_TYPE_E_ABOVE_0, t);
             // Exponential
             let es = a0 * (a1 * (t - a2) * (t - a2)).exp();
 
@@ -146,19 +122,7 @@ pub fn t(e: Millivolts) -> Celsius {
         (false, true) => K_TYPE_T1,
         (false, false) => K_TYPE_T2,
     };
-
-    // Power Series
-    let ps = c[0]
-        + c[1] * e
-        + c[2] * e * e
-        + c[3] * e * e * e
-        + c[4] * e * e * e * e
-        + c[5] * e * e * e * e * e
-        + c[6] * e * e * e * e * e * e
-        + c[7] * e * e * e * e * e * e * e
-        + c[8] * e * e * e * e * e * e * e * e
-        + c[9] * e * e * e * e * e * e * e * e * e;
-
+    let ps = polyval(c, e);
     Celsius(ps)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ compile_error!(
 
 #[macro_use]
 mod test_utils;
+mod polyval;
 mod units;
 pub use units::{
     Celsius, FPExt, Fahrenheit, Kelvin, Millivolts, Rankine, Reaumur,

--- a/src/n_type.rs
+++ b/src/n_type.rs
@@ -1,6 +1,6 @@
 //! N-Type thermocouple data
+use crate::polyval::polyval;
 use crate::{Celsius, Millivolts, FP};
-
 const N_TYPE_E_BELOW_0: [FP; 9] = [
     0.000000000000E+00,
     0.261591059620E-01,
@@ -75,33 +75,12 @@ pub fn e(t: Celsius) -> Millivolts {
     let e = match t > 0.0 {
         false => {
             // -270ºC -> 0ºC
-            const C: [FP; 9] = N_TYPE_E_BELOW_0;
 
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
+            polyval(N_TYPE_E_BELOW_0, t)
         }
         _ => {
             // 0ºC -> 1300ºC
-            const C: [FP; 11] = N_TYPE_E_ABOVE_0;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
-                + C[9] * t * t * t * t * t * t * t * t * t
-                + C[10] * t * t * t * t * t * t * t * t * t * t
+            polyval(N_TYPE_E_ABOVE_0, t)
         }
     };
 
@@ -127,19 +106,7 @@ pub fn t(e: Millivolts) -> Celsius {
         (false, true) => N_TYPE_T1,
         (false, false) => N_TYPE_T2,
     };
-
-    // Power Series
-    let ps = c[0]
-        + c[1] * e
-        + c[2] * e * e
-        + c[3] * e * e * e
-        + c[4] * e * e * e * e
-        + c[5] * e * e * e * e * e
-        + c[6] * e * e * e * e * e * e
-        + c[7] * e * e * e * e * e * e * e
-        + c[8] * e * e * e * e * e * e * e * e
-        + c[9] * e * e * e * e * e * e * e * e * e;
-
+    let ps = polyval(c, e);
     Celsius(ps)
 }
 

--- a/src/polyval.rs
+++ b/src/polyval.rs
@@ -1,0 +1,23 @@
+use crate::FP;
+use core::usize;
+/// Fast evaluation of polynom using Horner method (https://en.wikipedia.org/wiki/Horner%27s_method)
+/// This seems to be the fastest sequential way. (Estrin's scheme is maybe to complicated for this crate)
+/// is not faster coefs.iter().rev().fold(0., |ret: f64, c| x * ret + c)
+/// (I just wanted to flex my iterators)
+/// Speed-wise, this :
+/// ```
+/// let mut ret = coefs[N_COEF - 1];
+/// for i in (0..(N_COEF - 1)).rev() {
+///     ret = x * ret + coefs[i];
+/// }
+/// ret
+/// ```
+///  is the same as this:
+#[inline(always)]
+pub fn polyval<const N_COEF: usize>(coefs: [FP; N_COEF], x: FP) -> FP {
+    coefs
+        .iter()
+        .rev()
+        .skip(1)
+        .fold(coefs[N_COEF - 1], |ret: f64, c| x * ret + c)
+}

--- a/src/r_type.rs
+++ b/src/r_type.rs
@@ -1,5 +1,5 @@
 //! R-Type thermocouple data
-use crate::{Celsius, Millivolts, FP};
+use crate::{polyval::polyval, Celsius, Millivolts, FP};
 
 const R_TYPE_E_BELOW_1064_18: [FP; 10] = [
     0.000000000000E+00,
@@ -94,39 +94,15 @@ pub fn e(t: Celsius) -> Millivolts {
     let e = match (t > 1064.18, t > 1664.5) {
         (false, _) => {
             // -50ºC -> 1064.18ºC
-            const C: [FP; 10] = R_TYPE_E_BELOW_1064_18;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
-                + C[9] * t * t * t * t * t * t * t * t * t
+            polyval(R_TYPE_E_BELOW_1064_18, t)
         }
         (true, false) => {
             // 1064.18ºC -> 1664.5ºC
-            const C: [FP; 6] = R_TYPE_E_ABOVE_1064_18_BELOW_1664_5;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
+            polyval(R_TYPE_E_ABOVE_1064_18_BELOW_1664_5, t)
         }
         (true, true) => {
             // 1664.5ºC -> 1768.1ºC
-            const C: [FP; 5] = R_TYPE_E_ABOVE_1664_5;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
+            polyval(R_TYPE_E_ABOVE_1664_5, t)
         }
     };
 
@@ -154,18 +130,7 @@ pub fn t(e: Millivolts) -> Celsius {
         (false, false, false) => R_TYPE_T3,
     };
 
-    // Power Series
-    let ps = c[0]
-        + c[1] * e
-        + c[2] * e * e
-        + c[3] * e * e * e
-        + c[4] * e * e * e * e
-        + c[5] * e * e * e * e * e
-        + c[6] * e * e * e * e * e * e
-        + c[7] * e * e * e * e * e * e * e
-        + c[8] * e * e * e * e * e * e * e * e
-        + c[9] * e * e * e * e * e * e * e * e * e
-        + c[10] * e * e * e * e * e * e * e * e * e * e;
+    let ps = polyval(c, e);
 
     Celsius(ps)
 }

--- a/src/s_type.rs
+++ b/src/s_type.rs
@@ -1,5 +1,5 @@
 //! S-Type thermocouple data
-use crate::{Celsius, Millivolts, FP};
+use crate::{polyval::polyval, Celsius, Millivolts, FP};
 
 const S_TYPE_E_BELOW_1064_18: [FP; 9] = [
     0.000000000000E+00,
@@ -88,37 +88,15 @@ pub fn e(t: Celsius) -> Millivolts {
     let e = match (t > 1064.18, t > 1664.5) {
         (false, _) => {
             // -50ºC -> 1064.18ºC
-            const C: [FP; 9] = S_TYPE_E_BELOW_1064_18;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
+            polyval(S_TYPE_E_BELOW_1064_18, t)
         }
         (true, false) => {
             // 1064.18ºC -> 1664.5ºC
-            const C: [FP; 5] = S_TYPE_E_ABOVE_1064_18_BELOW_1664_5;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
+            polyval(S_TYPE_E_ABOVE_1064_18_BELOW_1664_5, t)
         }
         (true, true) => {
             // 1664.5ºC -> 1768.1ºC
-            const C: [FP; 5] = S_TYPE_E_ABOVE_1664_5;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
+            polyval(S_TYPE_E_ABOVE_1664_5, t)
         }
     };
 
@@ -147,16 +125,7 @@ pub fn t(e: Millivolts) -> Celsius {
     };
 
     // Power Series
-    let ps = c[0]
-        + c[1] * e
-        + c[2] * e * e
-        + c[3] * e * e * e
-        + c[4] * e * e * e * e
-        + c[5] * e * e * e * e * e
-        + c[6] * e * e * e * e * e * e
-        + c[7] * e * e * e * e * e * e * e
-        + c[8] * e * e * e * e * e * e * e * e
-        + c[9] * e * e * e * e * e * e * e * e * e;
+    let ps = polyval(c, e);
 
     Celsius(ps)
 }

--- a/src/t_type.rs
+++ b/src/t_type.rs
@@ -1,5 +1,5 @@
 //! T-Type thermocouple data
-use crate::{Celsius, Millivolts, FP};
+use crate::{polyval::polyval, Celsius, Millivolts, FP};
 
 const T_TYPE_E_BELOW_0: [FP; 15] = [
     0.000000000000E+00,
@@ -63,64 +63,11 @@ pub fn e(t: Celsius) -> Millivolts {
     let e = match t > 0.0 {
         false => {
             // -270ºC -> 0ºC
-            const C: [FP; 15] = T_TYPE_E_BELOW_0;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
-                + C[9] * t * t * t * t * t * t * t * t * t
-                + C[10] * t * t * t * t * t * t * t * t * t * t
-                + C[11] * t * t * t * t * t * t * t * t * t * t * t
-                + C[12] * t * t * t * t * t * t * t * t * t * t * t * t
-                + C[13]
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                + C[14]
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
-                    * t
+            polyval(T_TYPE_E_BELOW_0, t)
         }
         _ => {
             // 0ºC -> 400ºC
-            const C: [FP; 9] = T_TYPE_E_ABOVE_0;
-
-            // Power Series
-            C[0] + C[1] * t
-                + C[2] * t * t
-                + C[3] * t * t * t
-                + C[4] * t * t * t * t
-                + C[5] * t * t * t * t * t
-                + C[6] * t * t * t * t * t * t
-                + C[7] * t * t * t * t * t * t * t
-                + C[8] * t * t * t * t * t * t * t * t
+            polyval(T_TYPE_E_ABOVE_0, t)
         }
     };
 
@@ -147,14 +94,7 @@ pub fn t(e: Millivolts) -> Celsius {
     };
 
     // Power Series
-    let ps = c[0]
-        + c[1] * e
-        + c[2] * e * e
-        + c[3] * e * e * e
-        + c[4] * e * e * e * e
-        + c[5] * e * e * e * e * e
-        + c[6] * e * e * e * e * e * e
-        + c[7] * e * e * e * e * e * e * e;
+    let ps = polyval(c, e);
 
     Celsius(ps)
 }


### PR DESCRIPTION
This crate heavily uses polynomials in order to convert measurements.
As far as I understood one of the goal of this crate is as well to not need lots of other crates/
I therefor implemented a simple polyval function.
On your benchmarks, it doubles the speed:

### Current version with benchmark modified to add more "work" : 
```rust
   let thermocouple = thermocouple::KType::new();

    b.iter(|| {
        for i in 0..1000000 {
            let _: Celsius =
                thermocouple.sense_temperature(Millivolts(2.0));
        }
    });
```
test bench_type_j_celcius ... bench:           4 ns/iter (+/- 0)
test bench_type_k_celcius ... bench:   5,311,150 ns/iter (+/- 229,939)
test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 1.93s
### new version with polyval and the same amount of iterations
running 2 tests
test bench_type_j_celcius ... bench:           2 ns/iter (+/- 0)
test bench_type_k_celcius ... bench:   2,775,020 ns/iter (+/- 101,011)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 0 filtered out; finished in 1.06s